### PR TITLE
Fix Phosphor asset path resolution

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,11 @@ module.exports = (eleventyConfig, attributes = {}) => {
 
     const globalAttributes = { ...defaultAttributes, ...attributes };
 
+    const phosphorCorePath = path.join(
+        path.dirname(require.resolve("@phosphor-icons/core")),
+        "../assets"
+    );
+
     const shortcodeHandler = (iconName, iconType = 'regular', attributes = {}) => {
         if (!iconName) {
             throw new Error(
@@ -33,7 +38,10 @@ module.exports = (eleventyConfig, attributes = {}) => {
         }
 
         // safetly get SVG content
-        const svgContent = fs.readFileSync(path.join(__dirname, `./node_modules/@phosphor-icons/core/assets/${iconType}/${fileName}.svg`), 'utf8');
+        const svgContent = fs.readFileSync(
+            path.join(phosphorCorePath, `./${iconType}/${fileName}.svg`),
+            "utf8"
+        );
 
         const $ = cheerio.load(svgContent, {
             xmlMode: true

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": ".eleventy.js",
   "scripts": {
     "update:icons.json": "node ./fetchIconsNames.js",
-    "build": "cd demo/; npx eleventy",
-    "dev": "cd demo/; npx eleventy --serve",
-    "test": "cd demo/; npx eleventy"
+    "build": "npx eleventy --config=./demo/.eleventy.js --input=./demo --output=./_site",
+    "dev": "npx eleventy --serve --config=./demo/.eleventy.js --input=./demo --output=./_site",
+    "test": "npx eleventy --config=./demo/.eleventy.js --input=./demo --output=./_site "
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This now uses Node's own module path resolution as a means to locate `@phosphor-icons/core/assets` both in development of this plugin, and on the end-user's machine.

It also updates the build scripts so that they will work on Windows :)